### PR TITLE
Updated for 6.6 interconnect demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ This module deploys a VCN and an Aviatrix transit gateway. Defining the Aviatrix
 
 **_OCI Regions containing multiple Availabilty Domains_** ```us-ashburn-1, us-phoenix-1, uk-london-1, eu-frankfurt-1```
 
+**_Updated version 99 to support 6.6_**
+
 ### Compatibility
 Module version | Terraform version | Controller version | Terraform provider version
 :--- | :--- | :--- | :---
+v99.9 | 1.18 | 6.6.5545 | 2.21.2
 v4.0.3 | 0.13, 0.14, 0.15 | >=6.4 | 2.19.5
 v4.0.2 | 0.13,0.14 | >= 6.4 | >= 2.19
 v3.0.1 | 0.13 | >=6.2 | >=2.17

--- a/main.tf
+++ b/main.tf
@@ -9,12 +9,11 @@ resource "aviatrix_vpc" "default" {
 
 #Transit GW
 resource "aviatrix_transit_gateway" "default" {
-  enable_active_mesh               = var.active_mesh
   cloud_type                       = 16
   vpc_reg                          = var.region
   gw_name                          = local.name
   gw_size                          = var.instance_size
-  vpc_id                           = aviatrix_vpc.default.name
+  vpc_id                           = aviatrix_vpc.default.vpc_id
   account_name                     = var.account
   subnet                           = local.subnet
   ha_subnet                        = var.ha_gw ? local.ha_subnet : null

--- a/variables.tf
+++ b/variables.tf
@@ -50,12 +50,6 @@ variable "learned_cidr_approval" {
   default     = "false"
 }
 
-variable "active_mesh" {
-  description = "Set to false to disable active mesh."
-  type        = bool
-  default     = true
-}
-
 variable "prefix" {
   description = "Boolean to determine if name will be prepended with avx-"
   type        = bool


### PR DESCRIPTION
- removed active_mesh (deprecated)
- tested with 6.6.5535 
- updated readme 